### PR TITLE
Updated the error Norweigian Flag

### DIFF
--- a/resources/flags.json
+++ b/resources/flags.json
@@ -69,7 +69,7 @@
         "label": "EN-NO",
         "title": "English to Norwegian Bokmal",
         "image_from": "US",
-        "image_to": "ES"
+        "image_to": "NO"
     },
     "EN-NL": {
         "label": "EN-NL",


### PR DESCRIPTION
The Norwegian flag was denoted as that of Spain's in 'flags.json'. Fixed with the correct abbreviation.